### PR TITLE
Add persistent contact feedback feature

### DIFF
--- a/backend/public/send_feedback.php
+++ b/backend/public/send_feedback.php
@@ -1,0 +1,39 @@
+<?php
+header('Content-Type: application/json');
+require __DIR__ . '/../vendor/autoload.php';
+use Mailgun\Mailgun;
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'error' => 'Method not allowed']);
+    exit;
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input || empty($input['name']) || empty($input['email']) || empty($input['message'])) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'Missing required fields']);
+    exit;
+}
+
+$name = trim($input['name']);
+$email = trim($input['email']);
+$message = trim($input['message']);
+
+try {
+    $mg = Mailgun::create('dba41dc21198fcc4ba525015085cc266-7c5e3295-2c874436');
+    $domain = 'sandboxe67f4501277d44af9f736a2154a5b6cb.mailgun.org';
+
+    $mg->messages()->send($domain, [
+        'from' => "$name <$email>",
+        'to' => 'n.sandore5140@gmail.com',
+        'subject' => 'StudentSphere Feedback',
+        'text' => "Feedback from $name <$email>:\n\n$message"
+    ]);
+
+    echo json_encode(['success' => true, 'message' => 'Feedback sent']);
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'error' => 'Mailgun error: ' . $e->getMessage()]);
+}
+?>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -50,6 +50,7 @@ import LeftSidebar from './components/LeftSidebar';
 import NavBar from './components/NavBar';
 import ForumCard from './components/ForumCard';
 import Feed from './components/Feed';
+import ContactUsButton from './components/ContactUsButton';
 
 
 function App() {
@@ -365,6 +366,7 @@ function App() {
                       <div className="profile-page-main-content">
                         {userData ? <SelfProfileView userData={userData} /> : <Navigate to="/login" />}
                         <RightSidebar />
+                        <ContactUsButton />
                       </div>
                     }
                   />
@@ -486,6 +488,7 @@ function App() {
                           />
                         </Routes>
                         <RightSidebar />
+                        <ContactUsButton />
                       </div>
                     }
                   />

--- a/frontend/src/components/ContactUsButton.css
+++ b/frontend/src/components/ContactUsButton.css
@@ -1,0 +1,68 @@
+.contact-us-button {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  background-color: var(--primary-color);
+  color: #fff;
+  border: none;
+  padding: 0.75rem 1rem;
+  border-radius: 50px;
+  cursor: pointer;
+  z-index: 1000;
+}
+
+.feedback-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: var(--modal-overlay);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.feedback-content {
+  background: var(--modal-background);
+  padding: 1.5rem;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 400px;
+  box-shadow: 0 5px 15px rgba(0,0,0,0.3);
+  position: relative;
+}
+
+.feedback-content input,
+.feedback-content textarea {
+  width: 100%;
+  margin-bottom: 0.75rem;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.feedback-content button[type="submit"] {
+  background-color: var(--primary-color);
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.close-button {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: transparent;
+  border: none;
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+
+.status-message {
+  margin-bottom: 0.5rem;
+  color: var(--text-color);
+}

--- a/frontend/src/components/ContactUsButton.js
+++ b/frontend/src/components/ContactUsButton.js
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import './ContactUsButton.css';
+
+function ContactUsButton() {
+  const [open, setOpen] = useState(false);
+  const [formData, setFormData] = useState({ name: '', email: '', message: '' });
+  const [status, setStatus] = useState('');
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setStatus('');
+    try {
+      const res = await fetch('http://172.16.11.133/api/send_feedback.php', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(formData)
+      });
+      const data = await res.json();
+      if (res.ok && data.success) {
+        setStatus('Thank you for your feedback!');
+        setFormData({ name: '', email: '', message: '' });
+      } else {
+        setStatus(data.error || 'Failed to send feedback.');
+      }
+    } catch (err) {
+      setStatus('Failed to send feedback.');
+    }
+  };
+
+  return (
+    <>
+      <button className="contact-us-button" onClick={() => setOpen(true)}>
+        Contact Us
+      </button>
+      {open && (
+        <div className="feedback-modal">
+          <div className="feedback-content">
+            <button className="close-button" onClick={() => setOpen(false)}>×</button>
+            <h3>Send Feedback</h3>
+            <form onSubmit={handleSubmit}>
+              <input
+                type="text"
+                name="name"
+                placeholder="Your Name"
+                value={formData.name}
+                onChange={handleChange}
+                required
+              />
+              <input
+                type="email"
+                name="email"
+                placeholder="Your Email"
+                value={formData.email}
+                onChange={handleChange}
+                required
+              />
+              <textarea
+                name="message"
+                placeholder="Your Feedback"
+                value={formData.message}
+                onChange={handleChange}
+                required
+              />
+              {status && <p className="status-message">{status}</p>}
+              <button type="submit">Submit</button>
+            </form>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+export default ContactUsButton;


### PR DESCRIPTION
## Summary
- create backend endpoint to send feedback email
- add floating Contact Us button and modal form
- show Contact Us button throughout the site after account setup

## Testing
- `npm test --prefix frontend --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e9ac72b88333af586f5fffd1f1da