### PR TITLE
Show follower counts on profile pages

### DIFF
--- a/backend/public/fetch_follower_count.php
+++ b/backend/public/fetch_follower_count.php
@@ -24,20 +24,22 @@ try {
     // Get the database connection
     $db = getDB();
 
-    // Fetch the count of followers (users who have accepted connections with this user)
+    // Fetch the follower_count stored on the user record
     $queryFollowersCount = "
-        SELECT COUNT(*) AS follower_count
-        FROM connections
-        WHERE user_id2 = :user_id AND status = 'accepted'
+        SELECT follower_count
+        FROM users
+        WHERE id = :user_id
+        LIMIT 1
     ";
     $stmtFollowersCount = $db->prepare($queryFollowersCount);
     $stmtFollowersCount->execute([':user_id' => $user_id]);
     $result = $stmtFollowersCount->fetch(PDO::FETCH_ASSOC);
+    $count = $result ? (int) $result['follower_count'] : 0;
 
     // Return the follower count
     echo json_encode([
         'success' => true,
-        'follower_count' => $result['follower_count']
+        'follower_count' => $count
     ]);
 } catch (PDOException $e) {
     http_response_code(500);

--- a/backend/public/fetch_group.php
+++ b/backend/public/fetch_group.php
@@ -17,7 +17,13 @@ $community_id = intval($_GET['community_id']);
 
 try {
     $db = getDB();
-    $stmt = $db->prepare("SELECT * FROM communities WHERE id = :id AND community_type = 'group'");
+    $stmt = $db->prepare(
+        "SELECT c.*, COUNT(fc.user_id) AS followers_count
+         FROM communities c
+         LEFT JOIN followed_communities fc ON fc.community_id = c.id
+         WHERE c.id = :id AND c.community_type = 'group'
+         GROUP BY c.id"
+    );
     $stmt->execute([':id' => $community_id]);
     $group = $stmt->fetch(PDO::FETCH_ASSOC);
     if (!$group) {

--- a/backend/public/fetch_university.php
+++ b/backend/public/fetch_university.php
@@ -17,7 +17,13 @@ $community_id = intval($_GET['community_id']);
 
 try {
     $db = getDB();
-    $stmt = $db->prepare("SELECT * FROM communities WHERE id = :id AND community_type = 'university'");
+    $stmt = $db->prepare(
+        "SELECT c.*, COUNT(fc.user_id) AS followers_count
+         FROM communities c
+         LEFT JOIN followed_communities fc ON fc.community_id = c.id
+         WHERE c.id = :id AND c.community_type = 'university'
+         GROUP BY c.id"
+    );
     $stmt->execute([':id' => $community_id]);
     $university = $stmt->fetch(PDO::FETCH_ASSOC);
     if (!$university) {

--- a/frontend/src/components/GroupProfile.js
+++ b/frontend/src/components/GroupProfile.js
@@ -9,6 +9,7 @@ function GroupProfile({ userData }) {
   const [group, setGroup] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [followersCount, setFollowersCount] = useState(0);
 
   // Fetch group details on mount (or when id changes)
   useEffect(() => {
@@ -17,6 +18,7 @@ function GroupProfile({ userData }) {
         const response = await axios.get(`/api/fetch_group.php?community_id=${id}`);
         if (response.data.success) {
           setGroup(response.data.group);
+          setFollowersCount(response.data.group.followers_count || 0);
         } else {
           setError(response.data.error);
         }
@@ -59,6 +61,7 @@ function GroupProfile({ userData }) {
         <h1 className="group-name">{group.name}</h1>
         <p className="group-tagline">{group.tagline}</p>
         <p className="group-location">{group.location}</p>
+        <p className="followers-count">{followersCount} Followers</p>
         {group.website && (
           <a href={group.website} target="_blank" rel="noopener noreferrer">
             Visit Website

--- a/frontend/src/components/UniversityProfile.js
+++ b/frontend/src/components/UniversityProfile.js
@@ -33,6 +33,7 @@ function UniversityProfile({ userData }) {
 
   // New state for connections: following and followers (fetched via fetch_connections_list.php)
   const [connections, setConnections] = useState({ following: [], followers: [] });
+  const [followersCount, setFollowersCount] = useState(0);
 
   // For demonstration, we include some mock ambassadors (in addition to fetched ones)
   const mockAmbassadors = [
@@ -120,6 +121,7 @@ function UniversityProfile({ userData }) {
         const response = await axios.get(`/api/fetch_university.php?community_id=${id}`);
         if (response.data.success) {
           setUniversity(response.data.university);
+          setFollowersCount(response.data.university.followers_count || 0);
           // Initialize editable fields with the current values
           setEditName(response.data.university.name || "");
           setEditTagline(response.data.university.tagline || "");
@@ -374,6 +376,7 @@ function UniversityProfile({ userData }) {
           <h1 className="university-name">{university.name}</h1>
           <p className="university-tagline">{university.tagline}</p>
           <p className="university-location">{university.location}</p>
+          <p className="followers-count">{followersCount} Followers</p>
           {university.website && (
             <a
               href={university.website}

--- a/frontend/src/components/UserProfileView.js
+++ b/frontend/src/components/UserProfileView.js
@@ -23,6 +23,7 @@ function UserProfileView({ userData }) {
   // Follow state for this profile (does the logged-in user follow this profile?)
   const [isFollowing, setIsFollowing] = useState(false);
   const [loadingFollowStatus, setLoadingFollowStatus] = useState(true);
+  const [followerCount, setFollowerCount] = useState(0);
 
   // Log if no userData is passed from the parent
   useEffect(() => {
@@ -130,6 +131,24 @@ function UserProfileView({ userData }) {
 
     checkFollowStatus();
   }, [userData, user_id]);
+
+  // --------------------------------------------------------------------------
+  // Fetch follower count for this profile
+  // --------------------------------------------------------------------------
+  useEffect(() => {
+    const fetchFollowerCount = async () => {
+      try {
+        const res = await axios.get(`/api/fetch_follower_count.php?user_id=${user_id}`);
+        if (res.data.success) {
+          setFollowerCount(res.data.follower_count);
+        }
+      } catch (err) {
+        console.error('Error fetching follower count:', err);
+      }
+    };
+
+    fetchFollowerCount();
+  }, [user_id]);
 
   // --------------------------------------------------------------------------
   // Handle follow/unfollow toggle
@@ -250,6 +269,7 @@ function UserProfileView({ userData }) {
             )}
           </h2>
           <p className="profile-headline">{displayHeadline}</p>
+          <p className="followers-count">{followerCount} Followers</p>
 
           {/* Follow/Unfollow and Message Buttons (only if viewing another user's profile) */}
           {userData && userData.user_id !== parseInt(user_id, 10) && (


### PR DESCRIPTION
## Summary
- include follower counts in `fetch_university.php` and `fetch_group.php`
- show follower counts on a user's profile
- show follower counts on university and group pages
- fix follower count query to use `users` table

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684647ab944c83338c692e8420afa6e5