### PR TITLE
Add follow counts on self profile

### DIFF
--- a/backend/public/fetch_following_count.php
+++ b/backend/public/fetch_following_count.php
@@ -1,0 +1,57 @@
+<?php
+// fetch_following_count.php
+
+// Enable error reporting for debugging (disable in production)
+ini_set('display_errors', 1);
+error_reporting(E_ALL);
+
+header('Content-Type: application/json');
+
+// Include database connection
+require_once __DIR__ . '/../db_connection.php';
+
+// Check that a user_id is provided
+if (!isset($_GET['user_id'])) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'Missing user_id']);
+    exit;
+}
+
+// Sanitize and retrieve the user_id
+$user_id = (int) $_GET['user_id'];
+
+try {
+    // Get the database connection
+    $db = getDB();
+
+    // Fetch the following_count stored on the user record
+    $queryFollowingCount = "
+        SELECT following_count
+        FROM users
+        WHERE user_id = :user_id
+        LIMIT 1
+    ";
+    $stmtFollowingCount = $db->prepare($queryFollowingCount);
+    $stmtFollowingCount->execute([':user_id' => $user_id]);
+    $result = $stmtFollowingCount->fetch(PDO::FETCH_ASSOC);
+    $count = $result ? (int) $result['following_count'] : 0;
+
+    // Return the following count
+    echo json_encode([
+        'success' => true,
+        'following_count' => $count
+    ]);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode([
+        'success' => false,
+        'error' => 'Database error: ' . $e->getMessage()
+    ]);
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode([
+        'success' => false,
+        'error' => 'Server error: ' . $e->getMessage()
+    ]);
+}
+?>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -831,7 +831,8 @@ input::placeholder, textarea::placeholder {
 
 .community-location,
 .community-tagline,
-.followers-count {
+.followers-count,
+.following-count {
   font-size: 0.85rem;
   margin-bottom: 0.2rem;
   color: var(--dark-text);
@@ -839,7 +840,8 @@ input::placeholder, textarea::placeholder {
 
 [data-theme="dark"] .community-location,
 [data-theme="dark"] .community-tagline,
-[data-theme="dark"] .followers-count {
+[data-theme="dark"] .followers-count,
+[data-theme="dark"] .following-count {
   color: var(--light-text);
 }
 

--- a/frontend/src/components/SelfProfileView.js
+++ b/frontend/src/components/SelfProfileView.js
@@ -38,6 +38,10 @@ function SelfProfileView({ userData, onProfileUpdate }) {
   const [verified, setVerified] = useState(false);
   const [verifiedCommunityName, setVerifiedCommunityName] = useState('');
 
+  // Follower/Following counts
+  const [followerCount, setFollowerCount] = useState(0);
+  const [followingCount, setFollowingCount] = useState(0);
+
   // --------------------------------------------------------------------------
   // Fetch full profile from /api/fetch_user.php
   // --------------------------------------------------------------------------
@@ -97,6 +101,32 @@ function SelfProfileView({ userData, onProfileUpdate }) {
       fetchVerificationCommunity(profile.verified_community_id);
     }
   }, [verified, profile]);
+
+  // --------------------------------------------------------------------------
+  // Fetch follower and following counts
+  // --------------------------------------------------------------------------
+  useEffect(() => {
+    if (!userData) return;
+    const fetchCounts = async () => {
+      try {
+        const resFollowers = await axios.get(
+          `/api/fetch_follower_count.php?user_id=${userData.user_id}`
+        );
+        if (resFollowers.data.success) {
+          setFollowerCount(resFollowers.data.follower_count);
+        }
+        const resFollowing = await axios.get(
+          `/api/fetch_following_count.php?user_id=${userData.user_id}`
+        );
+        if (resFollowing.data.success) {
+          setFollowingCount(resFollowing.data.following_count);
+        }
+      } catch (err) {
+        console.error('Error fetching follow counts:', err);
+      }
+    };
+    fetchCounts();
+  }, [userData]);
 
   // --------------------------------------------------------------------------
   // Fetch experience & education data
@@ -342,6 +372,8 @@ function SelfProfileView({ userData, onProfileUpdate }) {
                     )}
                   </h2>
                   <p className="profile-headline">{displayHeadline}</p>
+                  <p className="followers-count">{followerCount} Followers</p>
+                  <p className="following-count">{followingCount} Following</p>
                 </>
               )}
             </div>


### PR DESCRIPTION
## Summary
- create API endpoint for following count
- show follower and following counts on SelfProfileView
- style following-count like followers-count

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68464ed525dc83339c8640f3385af98d