### PR TITLE
Add basic messaging support

### DIFF
--- a/backend/public/fetch_conversations.php
+++ b/backend/public/fetch_conversations.php
@@ -1,0 +1,43 @@
+<?php
+session_start();
+require_once __DIR__ . '/../db_connection.php';
+header('Content-Type: application/json');
+
+if (!isset($_GET['user_id'])) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'user_id is required']);
+    exit;
+}
+$user_id = (int)$_GET['user_id'];
+
+try {
+    $db = getDB();
+    $query = "
+        SELECT m.conversation_id,
+               CASE WHEN m.sender_id = :uid THEN m.recipient_id ELSE m.sender_id END AS other_user_id,
+               u.first_name, u.last_name, u.avatar_path,
+               m.content AS last_message,
+               m.created_at AS last_date,
+               (
+                   SELECT COUNT(*) FROM messages
+                   WHERE conversation_id = m.conversation_id
+                     AND recipient_id = :uid AND is_read = 0
+               ) AS unread_count
+        FROM messages m
+        JOIN (
+            SELECT conversation_id, MAX(created_at) AS max_date
+            FROM messages
+            WHERE sender_id = :uid OR recipient_id = :uid
+            GROUP BY conversation_id
+        ) t ON m.conversation_id = t.conversation_id AND m.created_at = t.max_date
+        JOIN users u ON u.user_id = CASE WHEN m.sender_id = :uid THEN m.recipient_id ELSE m.sender_id END
+        ORDER BY m.created_at DESC";
+    $stmt = $db->prepare($query);
+    $stmt->execute([':uid' => $user_id]);
+    $conversations = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    echo json_encode(['success' => true, 'conversations' => $conversations]);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'error' => 'Database error: ' . $e->getMessage()]);
+}
+?>

--- a/backend/public/fetch_messages.php
+++ b/backend/public/fetch_messages.php
@@ -1,0 +1,30 @@
+<?php
+session_start();
+require_once __DIR__ . '/../db_connection.php';
+header('Content-Type: application/json');
+
+if (!isset($_GET['conversation_id']) || !isset($_GET['user_id'])) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'conversation_id and user_id are required']);
+    exit;
+}
+
+$conversation_id = (int)$_GET['conversation_id'];
+$user_id = (int)$_GET['user_id'];
+
+try {
+    $db = getDB();
+    $stmt = $db->prepare("SELECT message_id, sender_id, recipient_id, content, is_read, created_at FROM messages WHERE conversation_id = :cid ORDER BY created_at ASC");
+    $stmt->execute([':cid' => $conversation_id]);
+    $messages = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    // Mark messages addressed to this user as read
+    $update = $db->prepare("UPDATE messages SET is_read = 1 WHERE conversation_id = :cid AND recipient_id = :uid");
+    $update->execute([':cid' => $conversation_id, ':uid' => $user_id]);
+
+    echo json_encode(['success' => true, 'messages' => $messages]);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'error' => 'Database error: ' . $e->getMessage()]);
+}
+?>

--- a/backend/public/search_users.php
+++ b/backend/public/search_users.php
@@ -1,0 +1,23 @@
+<?php
+require_once __DIR__ . '/../db_connection.php';
+header('Content-Type: application/json');
+
+$term = isset($_GET['term']) ? trim($_GET['term']) : '';
+if ($term === '') {
+    echo json_encode(['success' => true, 'users' => []]);
+    exit;
+}
+
+try {
+    $db = getDB();
+    $like = '%' . $term . '%';
+    $stmt = $db->prepare("SELECT user_id, first_name, last_name, avatar_path FROM users WHERE first_name LIKE :term OR last_name LIKE :term ORDER BY first_name LIMIT 10");
+    $stmt->bindValue(':term', $like, PDO::PARAM_STR);
+    $stmt->execute();
+    $users = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    echo json_encode(['success' => true, 'users' => $users]);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'error' => 'Database error: ' . $e->getMessage()]);
+}
+?>

--- a/backend/public/send_message.php
+++ b/backend/public/send_message.php
@@ -1,0 +1,70 @@
+<?php
+// send_message.php
+session_start();
+require_once __DIR__ . '/../db_connection.php';
+header('Content-Type: application/json');
+
+$input = file_get_contents('php://input');
+$data = json_decode($input, true);
+if (!$data) {
+    $data = $_POST;
+}
+
+if (!isset($data['sender_id'], $data['recipient_id'], $data['content'])) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'Missing sender_id, recipient_id, or content']);
+    exit;
+}
+
+$sender_id = (int)$data['sender_id'];
+$recipient_id = (int)$data['recipient_id'];
+$content = trim($data['content']);
+
+try {
+    $db = getDB();
+    // Find existing conversation between these two users
+    $stmt = $db->prepare(
+        "SELECT conversation_id FROM messages
+         WHERE (sender_id = :s AND recipient_id = :r)
+            OR (sender_id = :r AND recipient_id = :s)
+         ORDER BY message_id LIMIT 1"
+    );
+    $stmt->execute([':s' => $sender_id, ':r' => $recipient_id]);
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if ($row) {
+        $conversation_id = (int)$row['conversation_id'];
+    } else {
+        // Create a new conversation id
+        $stmt = $db->query("SELECT IFNULL(MAX(conversation_id),0)+1 AS next_id FROM messages");
+        $conversation_id = (int)$stmt->fetchColumn();
+    }
+
+    // Insert the message
+    $insert = $db->prepare(
+        "INSERT INTO messages
+            (sender_id, recipient_id, conversation_id, content, is_read, created_at, updated_at)
+         VALUES
+            (:sender_id, :recipient_id, :conversation_id, :content, 0, NOW(), NOW())"
+    );
+    $insert->execute([
+        ':sender_id' => $sender_id,
+        ':recipient_id' => $recipient_id,
+        ':conversation_id' => $conversation_id,
+        ':content' => $content,
+    ]);
+
+    // Add a notification for the recipient
+    $notif = $db->prepare(
+        "INSERT INTO notifications
+            (recipient_user_id, actor_user_id, notification_type, reference_id, message, created_at)
+         VALUES (?, ?, 'message', ?, 'New message', NOW())"
+    );
+    $notif->execute([$recipient_id, $sender_id, $conversation_id]);
+
+    echo json_encode(['success' => true, 'conversation_id' => $conversation_id]);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'error' => 'Database error: ' . $e->getMessage()]);
+}
+?>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -71,6 +71,7 @@ function App() {
 
   const [notifications, setNotifications] = useState([]);
   const [isNotificationsOpen, setIsNotificationsOpen] = useState(false);
+  const [unreadMessages, setUnreadMessages] = useState(0);
 
   const [showWelcome, setShowWelcome] = useState(false);
 
@@ -92,6 +93,7 @@ function App() {
           user.user_id = Number(user.user_id);
           setUserData(user);
           fetchNotifications(user.user_id);
+          fetchConversations(user.user_id);
         }
       } catch (err) {
         console.error('Error checking session:', err);
@@ -132,6 +134,21 @@ function App() {
     }
   };
 
+  const fetchConversations = async (user_id) => {
+    try {
+      const response = await axios.get(`http://172.16.11.133/api/fetch_conversations.php?user_id=${user_id}`, {
+        withCredentials: true,
+      });
+      if (response.data.success) {
+        const convs = response.data.conversations || [];
+        const total = convs.reduce((sum, c) => sum + Number(c.unread_count || 0), 0);
+        setUnreadMessages(total);
+      }
+    } catch (err) {
+      console.error('Error fetching conversations:', err);
+    }
+  };
+
   // Toggle Notification Pop-up
   const toggleNotifications = () => {
     setIsNotificationsOpen((prev) => !prev);
@@ -167,6 +184,8 @@ function App() {
     user.role_id = Number(user.role_id);
     user.user_id = Number(user.user_id);
     setUserData(user);
+    fetchNotifications(user.user_id);
+    fetchConversations(user.user_id);
     setStep(0);
   };
 
@@ -355,6 +374,7 @@ function App() {
                   isNotificationsOpen={isNotificationsOpen}
                   notificationRef={notificationRef}
                   markAllAsRead={markAllAsRead}
+                  unreadMessages={unreadMessages}
                 />
   
                 <Routes>

--- a/frontend/src/components/Connections.js
+++ b/frontend/src/components/Connections.js
@@ -137,7 +137,7 @@ function Connections({ userData }) {
                         >
                           Unfollow
                         </button>
-                        <button className="message-button">Message</button>
+                        <Link to={`/messages?user=${userId}`} className="message-button">Message</Link>
                       </div>
                     </li>
                   );
@@ -166,9 +166,9 @@ function Connections({ userData }) {
                         </p>
                         <p className="connection-headline">{user.headline || 'No headline'}</p>
                       </div>
-                      <button className="message-button">
+                      <Link to={`/messages?user=${userId}`} className="message-button">
                         Message
-                      </button>
+                      </Link>
                     </li>
                   );
                 })}

--- a/frontend/src/components/Messages.css
+++ b/frontend/src/components/Messages.css
@@ -9,46 +9,72 @@
     --transition-speed: 0.3s;
   }
   
-  .messages-container {
-    padding: 1rem;
-    background-color: var(--background-color);
-    border-radius: var(--border-radius);
-    box-shadow: var(--box-shadow);
-    font-family: Arial, sans-serif;
-  }
-  
-  .messages-container h1 {
-    text-align: center;
-    color: var(--primary-color);
-    margin-bottom: 1rem;
-  }
-  
-  .messages-list {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-  }
-  
-  .message-item {
-    padding: 1rem;
-    border-bottom: 1px solid #ddd;
-    display: flex;
-    flex-direction: column;
-    transition: background var(--transition-speed) ease;
-  }
-  
-  .message-item:hover {
-    background: #f7f7f7;
-  }
-  
-  .message-sender {
-    font-weight: bold;
-    margin-bottom: 0.5rem;
-    color: var(--text-color);
-  }
-  
-  .message-text {
-    color: var(--subtext-color);
-    font-size: 1rem;
-  }
+.messages-wrapper {
+  display: flex;
+  gap: 1rem;
+}
+
+.conversations-column {
+  width: 30%;
+  border-right: 1px solid #ddd;
+  padding-right: 1rem;
+}
+
+.messages-column {
+  flex: 1;
+}
+
+.conversation-list,
+.messages-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.conversation-list li {
+  padding: 0.5rem;
+  border-bottom: 1px solid #eee;
+  cursor: pointer;
+}
+
+.conversation-list li.active {
+  background: #f0f0f0;
+}
+
+.conversation-list .badge {
+  background: red;
+  color: #fff;
+  border-radius: 50%;
+  padding: 2px 6px;
+  margin-left: 4px;
+  font-size: 0.75rem;
+}
+
+.message-in,
+.message-out {
+  margin: 0.25rem 0;
+  padding: 0.5rem;
+  border-radius: 8px;
+  max-width: 60%;
+}
+
+.message-in {
+  background: #f1f1f1;
+}
+
+.message-out {
+  background: #daf1ff;
+  margin-left: auto;
+}
+
+.send-box {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.message-search {
+  width: 100%;
+  margin-bottom: 0.5rem;
+}
   

--- a/frontend/src/components/Messages.js
+++ b/frontend/src/components/Messages.js
@@ -1,42 +1,134 @@
-// src/components/Messages.js
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import './Messages.css';
+import { useSearchParams } from 'react-router-dom';
 
 function Messages({ userData }) {
+  const [conversations, setConversations] = useState([]);
+  const [activeConv, setActiveConv] = useState(null);
   const [messages, setMessages] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  const [newMessage, setNewMessage] = useState('');
+  const [searchTerm, setSearchTerm] = useState('');
+  const [searchResults, setSearchResults] = useState([]);
+  const [searchParams] = useSearchParams();
 
-  // For now, we'll fetch placeholder messages.
-  // Replace this logic with your actual messaging API later.
   useEffect(() => {
-    // Simulate a network request with a timeout
-    setTimeout(() => {
-      // Example placeholder messages:
-      setMessages([
-        { id: 1, from: 'Alice', text: 'Hey, how are you?' },
-        { id: 2, from: 'Bob', text: 'Did you see the latest news?' },
-        { id: 3, from: 'Charlie', text: 'Let’s catch up soon!' }
-      ]);
-      setLoading(false);
-    }, 1000);
-  }, []);
+    if (userData) {
+      fetchConversations();
+      const startUser = searchParams.get('user');
+      if (startUser) {
+        startConversation(Number(startUser));
+      }
+    }
+  }, [userData]);
 
-  if (loading) return <p>Loading messages...</p>;
-  if (error) return <p>{error}</p>;
+  const fetchConversations = async () => {
+    try {
+      const resp = await axios.get(`http://172.16.11.133/api/fetch_conversations.php?user_id=${userData.user_id}`, { withCredentials: true });
+      if (resp.data.success) {
+        setConversations(resp.data.conversations || []);
+      }
+    } catch (err) {
+      console.error('Error fetching conversations:', err);
+    }
+  };
+
+  const fetchMessages = async (conversation_id, other_user_id) => {
+    try {
+      const resp = await axios.get(`http://172.16.11.133/api/fetch_messages.php?conversation_id=${conversation_id}&user_id=${userData.user_id}`, { withCredentials: true });
+      if (resp.data.success) {
+        setMessages(resp.data.messages || []);
+        setActiveConv({ conversation_id, other_user_id });
+        fetchConversations();
+      }
+    } catch (err) {
+      console.error('Error fetching messages:', err);
+    }
+  };
+
+  const startConversation = async (other_user_id) => {
+    const existing = conversations.find(c => Number(c.other_user_id) === other_user_id);
+    if (existing) {
+      fetchMessages(existing.conversation_id, other_user_id);
+    } else {
+      setActiveConv({ conversation_id: null, other_user_id });
+      setMessages([]);
+    }
+  };
+
+  const handleSend = async () => {
+    if (!newMessage.trim() || !activeConv) return;
+    try {
+      const resp = await axios.post('http://172.16.11.133/api/send_message.php', {
+        sender_id: userData.user_id,
+        recipient_id: activeConv.other_user_id,
+        content: newMessage
+      }, { withCredentials: true });
+      setNewMessage('');
+      const cid = activeConv.conversation_id || resp.data.conversation_id;
+      fetchMessages(cid, activeConv.other_user_id);
+    } catch (err) {
+      console.error('Error sending message:', err);
+    }
+  };
+
+  const searchUsers = async (term) => {
+    setSearchTerm(term);
+    if (!term) { setSearchResults([]); return; }
+    try {
+      const resp = await axios.get(`http://172.16.11.133/api/search_users.php?term=${encodeURIComponent(term)}`, { withCredentials: true });
+      if (resp.data.success) setSearchResults(resp.data.users);
+    } catch (err) { console.error('Error searching users:', err); }
+  };
 
   return (
-    <div className="messages-container">
-      <h1>Messages</h1>
-      <ul className="messages-list">
-        {messages.map((msg) => (
-          <li key={msg.id} className="message-item">
-            <div className="message-sender">{msg.from}</div>
-            <div className="message-text">{msg.text}</div>
-          </li>
-        ))}
-      </ul>
+    <div className="messages-wrapper">
+      <div className="conversations-column">
+        <input
+          type="text"
+          value={searchTerm}
+          onChange={(e) => searchUsers(e.target.value)}
+          placeholder="Search users"
+          className="message-search"
+        />
+        {searchResults.length > 0 && (
+          <ul className="search-results">
+            {searchResults.map((u) => (
+              <li key={u.user_id} onClick={() => { setSearchResults([]); startConversation(u.user_id); }}>
+                {u.first_name} {u.last_name}
+              </li>
+            ))}
+          </ul>
+        )}
+        <ul className="conversation-list">
+          {conversations.map((c) => (
+            <li key={c.conversation_id} onClick={() => fetchMessages(c.conversation_id, c.other_user_id)} className={activeConv && activeConv.conversation_id === c.conversation_id ? 'active' : ''}>
+              <span>{c.first_name} {c.last_name}</span>
+              {Number(c.unread_count) > 0 && <span className="badge">{c.unread_count}</span>}
+              <div className="last-message">{c.last_message}</div>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="messages-column">
+        {activeConv ? (
+          <>
+            <div className="messages-list">
+              {messages.map((m) => (
+                <div key={m.message_id} className={m.sender_id === userData.user_id ? 'message-out' : 'message-in'}>
+                  {m.content}
+                </div>
+              ))}
+            </div>
+            <div className="send-box">
+              <input value={newMessage} onChange={(e) => setNewMessage(e.target.value)} placeholder="Type a message" />
+              <button onClick={handleSend}>Send</button>
+            </div>
+          </>
+        ) : (
+          <p>Select a conversation</p>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/NavBar.js
+++ b/frontend/src/components/NavBar.js
@@ -40,6 +40,7 @@ function NavBar({
   isNotificationsOpen,
   notificationRef,
   markAllAsRead,
+  unreadMessages,
 }) {
   const navigate = useNavigate();
   const unreadCount = notifications.filter(n => parseInt(n.is_read, 10) === 0).length;
@@ -116,7 +117,12 @@ function NavBar({
         <div className="nav-icons">
           {/* Messages link */}
           <Link to="/messages">
-            <FaEnvelope className="nav-icon" title="Messages" />
+            <div className="notification-container">
+              <FaEnvelope className="nav-icon" title="Messages" />
+              {unreadMessages > 0 && (
+                <span className="notification-badge">{unreadMessages}</span>
+              )}
+            </div>
           </Link>
 
           {/* Notifications */}

--- a/frontend/src/components/UniversityProfile.js
+++ b/frontend/src/components/UniversityProfile.js
@@ -463,12 +463,9 @@ function UniversityProfile({ userData }) {
                             Follow
                           </button>
                         )}
-                        <button
-                          className="message-button"
-                          onClick={() => alert(`Message ${amb.first_name} ${amb.last_name}`)}
-                        >
+                        <RouterLink to={`/messages?user=${amb.user_id}`} className="message-button">
                           Message
-                        </button>
+                        </RouterLink>
                       </>
                     )}
                   </li>

--- a/frontend/src/components/UserProfileView.js
+++ b/frontend/src/components/UserProfileView.js
@@ -261,7 +261,7 @@ function UserProfileView({ userData }) {
               >
                 {loadingFollowStatus ? "Loading..." : isFollowing ? "Unfollow" : "Follow"}
               </button>
-              <button className="message-button">Message</button>
+              <RouterLink to={`/messages?user=${user_id}`} className="message-button">Message</RouterLink>
             </div>
           )}
 


### PR DESCRIPTION
## Summary
- implement PHP endpoints for sending and retrieving messages
- add conversations and message list React component
- show unread message count in the navbar
- allow starting a conversation from user profiles and connection lists
- include user search endpoint for messaging

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a324a84248333873ecc89b84ddd76