### PR TITLE
Add password reset endpoint and UI

### DIFF
--- a/backend/public/reset_password.php
+++ b/backend/public/reset_password.php
@@ -1,0 +1,46 @@
+<?php
+header('Content-Type: application/json');
+require_once '../db_connection.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['error' => 'Method not allowed']);
+    exit;
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+$email = isset($input['email']) ? trim($input['email']) : '';
+$new_password = isset($input['new_password']) ? $input['new_password'] : '';
+
+if (empty($email) || empty($new_password)) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'Email and new password are required.']);
+    exit;
+}
+
+try {
+    $db = getDB();
+    // Check if user exists
+    $stmt = $db->prepare('SELECT user_id FROM users WHERE email = :email LIMIT 1');
+    $stmt->bindParam(':email', $email, PDO::PARAM_STR);
+    $stmt->execute();
+    $user = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if (!$user) {
+        http_response_code(404);
+        echo json_encode(['success' => false, 'error' => 'User not found.']);
+        exit;
+    }
+
+    $hashed = password_hash($new_password, PASSWORD_BCRYPT);
+    $update = $db->prepare('UPDATE users SET password_hash = :password_hash WHERE user_id = :user_id');
+    $update->bindParam(':password_hash', $hashed);
+    $update->bindParam(':user_id', $user['user_id'], PDO::PARAM_INT);
+    $update->execute();
+
+    echo json_encode(['success' => true]);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'error' => 'Database error: ' . $e->getMessage()]);
+}
+?>

--- a/frontend/src/components/Login.css
+++ b/frontend/src/components/Login.css
@@ -60,6 +60,12 @@
   .login-container button:hover {
     background: #005f8d;
   }
+
+  .error-message {
+    color: red;
+    font-size: 0.9rem;
+    margin-top: -1rem;
+  }
   
   .not-a-member {
     margin-top: 1rem;
@@ -94,4 +100,3 @@
       padding: 0.6rem;
     }
   }
-  

--- a/frontend/src/components/Login.js
+++ b/frontend/src/components/Login.js
@@ -8,6 +8,10 @@ function Login({ onLogin, onGoToSignUp }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
+  const [showReset, setShowReset] = useState(false);
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [resetMessage, setResetMessage] = useState('');
 
   const handleLoginClick = async (e) => {
     e.preventDefault();
@@ -37,38 +41,127 @@ function Login({ onLogin, onGoToSignUp }) {
     }
   };
 
+  const handleResetPassword = async (e) => {
+    e.preventDefault();
+
+    if (!email || !newPassword || !confirmPassword) {
+      setResetMessage('Please fill out all fields.');
+      return;
+    }
+
+    if (newPassword !== confirmPassword) {
+      setResetMessage('Passwords do not match.');
+      return;
+    }
+
+    try {
+      const response = await axios.post('http://172.16.11.133/api/reset_password.php', {
+        email,
+        new_password: newPassword,
+      });
+
+      if (response.data && response.data.success) {
+        setResetMessage('Password updated. You can now log in.');
+        setShowReset(false);
+        setPassword('');
+        setNewPassword('');
+        setConfirmPassword('');
+      } else {
+        setResetMessage(response.data.error || 'Failed to reset password.');
+      }
+    } catch (err) {
+      setResetMessage('Server error. Please try again later.');
+    }
+  };
+
   return (
     <div className="login-container">
       <h2>Login to StudentSphere</h2>
-      <form onSubmit={handleLoginClick}>
-        <label htmlFor="email">Email:</label>
-        <input
-          type="email"
-          name="email"
-          id="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          required
-        />
+      {showReset ? (
+        <form onSubmit={handleResetPassword}>
+          <label htmlFor="email">Email:</label>
+          <input
+            type="email"
+            name="email"
+            id="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
 
-        <label htmlFor="password">Password:</label>
-        <input
-          type="password"
-          name="password"
-          id="password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          required
-        />
+          <label htmlFor="new-password">New Password:</label>
+          <input
+            type="password"
+            name="new-password"
+            id="new-password"
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            required
+          />
 
-        {error && <p className="error-message">{error}</p>}
+          <label htmlFor="confirm-password">Confirm Password:</label>
+          <input
+            type="password"
+            name="confirm-password"
+            id="confirm-password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            required
+          />
 
-        <button type="submit">Login</button>
-      </form>
+          {resetMessage && <p className="error-message">{resetMessage}</p>}
 
-      <div className="not-a-member">
-        Not a Member? <span className="sign-up-link" onClick={onGoToSignUp}>Sign Up</span>
-      </div>
+          <button type="submit">Reset Password</button>
+          <div className="not-a-member">
+            Remembered?{' '}
+            <span className="sign-up-link" onClick={() => setShowReset(false)}>
+              Back to Login
+            </span>
+          </div>
+        </form>
+      ) : (
+        <>
+          <form onSubmit={handleLoginClick}>
+            <label htmlFor="email">Email:</label>
+            <input
+              type="email"
+              name="email"
+              id="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+
+            <label htmlFor="password">Password:</label>
+            <input
+              type="password"
+              name="password"
+              id="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+
+            {error && <p className="error-message">{error}</p>}
+
+            <button type="submit">Login</button>
+          </form>
+
+          <div className="not-a-member">
+            Not a Member?{' '}
+            <span className="sign-up-link" onClick={onGoToSignUp}>
+              Sign Up
+            </span>
+          </div>
+
+          <div className="not-a-member">
+            Forgot your password?{' '}
+            <span className="sign-up-link" onClick={() => setShowReset(true)}>
+              Reset Password
+            </span>
+          </div>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add backend `reset_password.php` API endpoint
- enhance `Login.js` with a password reset form
- style error messages in `Login.css`

## Testing
- `npm test --silent`
- `vendor/bin/phpunit --version` *(fails: no such file)*

------
https://chatgpt.com/codex/tasks/task_e_684a3ba568e483338d4c16b531d8a95c