### PR TITLE
Fix UserProfileView privacy display

### DIFF
--- a/backend/public/user_experience.php
+++ b/backend/public/user_experience.php
@@ -45,6 +45,9 @@ try {
         if ($is_public === 0 && $viewer_id !== $user_id) {
             $row['start_date'] = null;
             $row['end_date'] = null;
+            $row['location_city'] = null;
+            $row['location_state'] = null;
+            $row['location_country'] = null;
         }
 
         $experiences[] = $row;

--- a/frontend/src/components/UserProfileView.js
+++ b/frontend/src/components/UserProfileView.js
@@ -25,6 +25,14 @@ function UserProfileView({ userData }) {
   const [loadingFollowStatus, setLoadingFollowStatus] = useState(true);
   const [followerCount, setFollowerCount] = useState(0);
 
+  // Experience & Education states
+  const [experience, setExperience] = useState([]);
+  const [education, setEducation] = useState([]);
+  const [loadingExp, setLoadingExp] = useState(true);
+  const [loadingEdu, setLoadingEdu] = useState(true);
+  const [errorExp, setErrorExp] = useState(null);
+  const [errorEdu, setErrorEdu] = useState(null);
+
   // Log if no userData is passed from the parent
   useEffect(() => {
     if (!userData) {
@@ -148,6 +156,37 @@ function UserProfileView({ userData }) {
     };
 
     fetchFollowerCount();
+  }, [user_id]);
+
+  // --------------------------------------------------------------------------
+  // Fetch experience & education for this profile
+  // --------------------------------------------------------------------------
+  useEffect(() => {
+    setLoadingExp(true);
+    axios
+      .get(`/api/user_experience.php?user_id=${user_id}`, { withCredentials: true })
+      .then((res) => {
+        setExperience(res.data);
+        setLoadingExp(false);
+      })
+      .catch((err) => {
+        console.error('Error fetching experience:', err);
+        setErrorExp('Error fetching experience');
+        setLoadingExp(false);
+      });
+
+    setLoadingEdu(true);
+    axios
+      .get(`/api/user_education.php?user_id=${user_id}`, { withCredentials: true })
+      .then((res) => {
+        setEducation(res.data);
+        setLoadingEdu(false);
+      })
+      .catch((err) => {
+        console.error('Error fetching education:', err);
+        setErrorEdu('Error fetching education');
+        setLoadingEdu(false);
+      });
   }, [user_id]);
 
   // --------------------------------------------------------------------------
@@ -307,6 +346,83 @@ function UserProfileView({ userData }) {
       <div className="profile-section">
         <h3>About</h3>
         <p>{DOMPurify.sanitize(displayAbout)}</p>
+      </div>
+
+      {/* Experience Section */}
+      <div className="profile-section">
+        <h3>Experience</h3>
+        {loadingExp ? (
+          <p>Loading experience...</p>
+        ) : errorExp ? (
+          <p>{errorExp}</p>
+        ) : experience.length > 0 ? (
+          experience.map((exp, index) => (
+            <div key={index} className="experience-item">
+              <h4>
+                {exp.title} at {exp.company}
+              </h4>
+              <div className="experience-dates">
+                {exp.start_date} - {exp.end_date ? exp.end_date : "Present"}
+              </div>
+              <div className="experience-meta">
+                {/*<span className="experience-industry">{exp.industry}</span>*/}
+                <span className="experience-type">{exp.employment_type}</span>
+                <span className="experience-location">
+                  {exp.location_city}
+                  {exp.location_state ? `, ${exp.location_state}` : ""}
+                </span>
+              </div>
+              <p>{exp.description}</p>
+              {exp.responsibilities && exp.responsibilities.length > 0 && (
+                <ul className="responsibilities-list">
+                  {exp.responsibilities.map((resp, idx) => (
+                    <li key={idx}>{resp}</li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          ))
+        ) : (
+          <p>No experience added yet.</p>
+        )}
+      </div>
+
+      {/* Education Section */}
+      <div className="profile-section">
+        <h3>Education</h3>
+        {loadingEdu ? (
+          <p>Loading education...</p>
+        ) : errorEdu ? (
+          <p>{errorEdu}</p>
+        ) : education.length > 0 ? (
+          education.map((edu, index) => (
+            <div key={index} className="education-item">
+              <h4>
+                {edu.degree} in {edu.field_of_study}
+              </h4>
+              <div className="education-institution">{edu.institution}</div>
+              <div className="education-dates">
+                {edu.start_date} - {edu.end_date ? edu.end_date : "Present"}
+              </div>
+              {edu.gpa && <div className="education-gpa">GPA: {edu.gpa}</div>}
+              {edu.honors && <div className="education-honors">Honors: {edu.honors}</div>}
+              {edu.activities_societies && (
+                <div className="education-activities">
+                  Activities: {edu.activities_societies}
+                </div>
+              )}
+              {edu.achievements && edu.achievements.length > 0 && (
+                <ul className="achievements-list">
+                  {edu.achievements.map((ach, idx) => (
+                    <li key={idx}>{ach}</li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          ))
+        ) : (
+          <p>No education details added yet.</p>
+        )}
       </div>
 
       {/* Skills Section */}


### PR DESCRIPTION
## Summary
- show experience and education on public user profile pages
- fetch experience and education data in UserProfileView
- hide location details for private profiles in user_experience.php

## Testing
- `npm test --prefix frontend --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a486c0d7083339eb0b19aea785bc9