### PR TITLE
Implement connection request acceptance

### DIFF
--- a/backend/public/cancel_connection.php
+++ b/backend/public/cancel_connection.php
@@ -1,0 +1,32 @@
+<?php
+// cancel_connection.php
+
+require_once __DIR__ . '/../db_connection.php';
+header('Content-Type: application/json');
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input) { $input = $_POST; }
+
+if (!isset($input['connection_id'])) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'Missing connection_id']);
+    exit;
+}
+
+$connection_id = (int)$input['connection_id'];
+
+try {
+    $db = getDB();
+    $stmt = $db->prepare("DELETE FROM connections WHERE connection_id = :cid AND status = 'pending'");
+    $stmt->execute([':cid' => $connection_id]);
+    if ($stmt->rowCount() === 0) {
+        http_response_code(404);
+        echo json_encode(['success' => false, 'error' => 'Connection not found']);
+        exit;
+    }
+    echo json_encode(['success' => true]);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'error' => 'Database error: ' . $e->getMessage()]);
+}
+?>

--- a/backend/public/fetch_connection_requests.php
+++ b/backend/public/fetch_connection_requests.php
@@ -1,0 +1,35 @@
+<?php
+// fetch_connection_requests.php
+require_once __DIR__ . '/../db_connection.php';
+header('Content-Type: application/json');
+
+if (!isset($_GET['user_id'])) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'Missing user_id']);
+    exit;
+}
+
+$user_id = (int)$_GET['user_id'];
+
+try {
+    $db = getDB();
+    $incomingStmt = $db->prepare("SELECT connection_id, user_id1 FROM connections WHERE user_id2 = :uid AND status = 'pending'");
+    $incomingStmt->execute([':uid' => $user_id]);
+    $incoming = [];
+    while ($row = $incomingStmt->fetch(PDO::FETCH_ASSOC)) {
+        $incoming[] = ['connection_id' => (int)$row['connection_id'], 'user_id' => (int)$row['user_id1']];
+    }
+
+    $outgoingStmt = $db->prepare("SELECT connection_id, user_id2 FROM connections WHERE user_id1 = :uid AND status = 'pending'");
+    $outgoingStmt->execute([':uid' => $user_id]);
+    $outgoing = [];
+    while ($row = $outgoingStmt->fetch(PDO::FETCH_ASSOC)) {
+        $outgoing[] = ['connection_id' => (int)$row['connection_id'], 'user_id' => (int)$row['user_id2']];
+    }
+
+    echo json_encode(['success' => true, 'incoming' => $incoming, 'outgoing' => $outgoing]);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'error' => 'Database error: ' . $e->getMessage()]);
+}
+?>

--- a/backend/public/fetch_connection_status.php
+++ b/backend/public/fetch_connection_status.php
@@ -15,11 +15,20 @@ $user_id2 = (int)$_GET['user_id2'];
 
 try {
     $db = getDB();
-    $stmt = $db->prepare("SELECT status FROM connections WHERE (user_id1 = :u1 AND user_id2 = :u2) OR (user_id1 = :u2 AND user_id2 = :u1)");
+    $stmt = $db->prepare("SELECT connection_id, user_id1, user_id2, status FROM connections WHERE (user_id1 = :u1 AND user_id2 = :u2) OR (user_id1 = :u2 AND user_id2 = :u1)");
     $stmt->execute([':u1' => $user_id1, ':u2' => $user_id2]);
     $row = $stmt->fetch(PDO::FETCH_ASSOC);
-    $status = $row ? $row['status'] : 'none';
-    echo json_encode(['success' => true, 'status' => $status]);
+    if ($row) {
+        $response = [
+            'success' => true,
+            'status' => $row['status'],
+            'connection_id' => (int)$row['connection_id'],
+            'is_sender' => ($row['user_id1'] == $user_id1)
+        ];
+    } else {
+        $response = ['success' => true, 'status' => 'none'];
+    }
+    echo json_encode($response);
 } catch (PDOException $e) {
     http_response_code(500);
     echo json_encode(['success' => false, 'error' => 'Database error: ' . $e->getMessage()]);

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -30,7 +30,7 @@ import {
 } from 'react-icons/fa';
 import { TbWriting } from 'react-icons/tb';
 import { BiInfoCircle } from 'react-icons/bi';
-import Connections from './components/Connections';
+import UserConnections from './components/UserConnections';
 import { RiMedalFill } from 'react-icons/ri';
 import SignUp from './components/SignUp';
 import InterestSelection from './components/InterestSelection';
@@ -452,7 +452,7 @@ function App() {
                           <Route
                             path="/connections"
                             element={
-                              userData ? <Connections userData={userData} /> : <Navigate to="/login" />
+                              userData ? <UserConnections userData={userData} /> : <Navigate to="/login" />
                             }
                           />
 

--- a/frontend/src/components/UserConnections.js
+++ b/frontend/src/components/UserConnections.js
@@ -1,0 +1,197 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import { Link } from 'react-router-dom';
+import './Connections.css';
+
+function UserConnections({ userData }) {
+  const [activeTab, setActiveTab] = useState('connections');
+  const [connections, setConnections] = useState([]);
+  const [incoming, setIncoming] = useState([]);
+  const [outgoing, setOutgoing] = useState([]);
+  const [userDetails, setUserDetails] = useState({});
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!userData) return;
+    const fetchAll = async () => {
+      try {
+        const connRes = await axios.get(`/api/fetch_user_connections.php?user_id=${userData.user_id}`);
+        if (connRes.data.success) {
+          setConnections(connRes.data.connections);
+        }
+        const reqRes = await axios.get(`/api/fetch_connection_requests.php?user_id=${userData.user_id}`);
+        if (reqRes.data.success) {
+          setIncoming(reqRes.data.incoming);
+          setOutgoing(reqRes.data.outgoing);
+          const ids = [
+            ...connRes.data.connections,
+            ...reqRes.data.incoming.map(r => r.user_id),
+            ...reqRes.data.outgoing.map(r => r.user_id)
+          ];
+          fetchUserDetails(ids);
+        }
+      } catch (err) {
+        console.error('Error fetching connections:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchAll();
+  }, [userData]);
+
+  const fetchUserDetails = async (ids) => {
+    const info = { ...userDetails };
+    for (let uid of ids) {
+      if (info[uid]) continue;
+      try {
+        const res = await axios.get(`/api/fetch_user.php?user_id=${uid}`);
+        if (res.data.success) info[uid] = res.data.user;
+      } catch (err) {}
+    }
+    setUserDetails(info);
+  };
+
+  const acceptRequest = async (connectionId) => {
+    try {
+      await axios.post('/api/accept_connection.php', { connection_id: connectionId }, { withCredentials: true });
+      setIncoming(prev => prev.filter(r => r.connection_id !== connectionId));
+      setConnections(prev => [...prev, incoming.find(r => r.connection_id === connectionId).user_id]);
+    } catch (err) {
+      console.error('Error accepting connection:', err);
+    }
+  };
+
+  const cancelRequest = async (connectionId, isOutgoing = false) => {
+    try {
+      await axios.post('/api/cancel_connection.php', { connection_id: connectionId }, { withCredentials: true });
+      if (isOutgoing) {
+        setOutgoing(prev => prev.filter(r => r.connection_id !== connectionId));
+      } else {
+        setIncoming(prev => prev.filter(r => r.connection_id !== connectionId));
+      }
+    } catch (err) {
+      console.error('Error cancelling request:', err);
+    }
+  };
+
+  return (
+    <div className="connections-container">
+      <div className="feed-header">
+        <h2>Connections</h2>
+        <div className="feed-toggle-buttons">
+          <button
+            className={`feed-option-button ${activeTab === 'connections' ? 'active' : ''}`}
+            onClick={() => setActiveTab('connections')}
+          >
+            Connections
+          </button>
+          <button
+            className={`feed-option-button ${activeTab === 'incoming' ? 'active' : ''}`}
+            onClick={() => setActiveTab('incoming')}
+          >
+            Incoming Requests
+          </button>
+          <button
+            className={`feed-option-button ${activeTab === 'outgoing' ? 'active' : ''}`}
+            onClick={() => setActiveTab('outgoing')}
+          >
+            Pending
+          </button>
+        </div>
+      </div>
+      {loading ? (
+        <p>Loading...</p>
+      ) : (
+        <div className="connections-list">
+          {activeTab === 'connections' && (
+            connections.length === 0 ? (
+              <p>No connections yet.</p>
+            ) : (
+              <ul>
+                {connections.map(uid => {
+                  const user = userDetails[uid] || {};
+                  return (
+                    <li key={uid}>
+                      <img
+                        src={user.avatar_path || '/uploads/avatars/default-avatar.png'}
+                        alt={`${user.first_name || ''} ${user.last_name || ''}`}
+                        className="connection-avatar"
+                      />
+                      <div className="connection-info">
+                        <p className="connection-name">
+                          <Link to={`/user/${uid}`}>{user.first_name} {user.last_name}</Link>
+                        </p>
+                        <p className="connection-headline">{user.headline || 'No headline'}</p>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            )
+          )}
+          {activeTab === 'incoming' && (
+            incoming.length === 0 ? (
+              <p>No incoming requests.</p>
+            ) : (
+              <ul>
+                {incoming.map(req => {
+                  const user = userDetails[req.user_id] || {};
+                  return (
+                    <li key={req.connection_id}>
+                      <img
+                        src={user.avatar_path || '/uploads/avatars/default-avatar.png'}
+                        alt={`${user.first_name || ''} ${user.last_name || ''}`}
+                        className="connection-avatar"
+                      />
+                      <div className="connection-info">
+                        <p className="connection-name">
+                          <Link to={`/user/${req.user_id}`}>{user.first_name} {user.last_name}</Link>
+                        </p>
+                        <p className="connection-headline">{user.headline || 'No headline'}</p>
+                      </div>
+                      <div className="connection-actions">
+                        <button className="follow-button" onClick={() => acceptRequest(req.connection_id)}>Accept</button>
+                        <button className="follow-button unfollow" onClick={() => cancelRequest(req.connection_id)}>Decline</button>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            )
+          )}
+          {activeTab === 'outgoing' && (
+            outgoing.length === 0 ? (
+              <p>No pending requests.</p>
+            ) : (
+              <ul>
+                {outgoing.map(req => {
+                  const user = userDetails[req.user_id] || {};
+                  return (
+                    <li key={req.connection_id}>
+                      <img
+                        src={user.avatar_path || '/uploads/avatars/default-avatar.png'}
+                        alt={`${user.first_name || ''} ${user.last_name || ''}`}
+                        className="connection-avatar"
+                      />
+                      <div className="connection-info">
+                        <p className="connection-name">
+                          <Link to={`/user/${req.user_id}`}>{user.first_name} {user.last_name}</Link>
+                        </p>
+                        <p className="connection-headline">{user.headline || 'No headline'}</p>
+                      </div>
+                      <div className="connection-actions">
+                        <button className="follow-button unfollow" onClick={() => cancelRequest(req.connection_id, true)}>Unsend</button>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            )
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default UserConnections;


### PR DESCRIPTION
## Summary
- provide cancel and fetch APIs for connection requests
- return connection id and sender info in connection status API
- update notification for connection requests with sender link
- enable accept/cancel on user profile
- add connections page showing connections, incoming, and pending requests

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a5807ee108333b5711217373ac530