### PR TITLE
Add connection management options

### DIFF
--- a/backend/public/remove_connection.php
+++ b/backend/public/remove_connection.php
@@ -1,0 +1,35 @@
+<?php
+// remove_connection.php
+
+require_once __DIR__ . '/../db_connection.php';
+header('Content-Type: application/json');
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input) { $input = $_POST; }
+
+if (!isset($input['user_id1']) || !isset($input['user_id2'])) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'Missing user_id1 or user_id2']);
+    exit;
+}
+
+$user_id1 = (int)$input['user_id1'];
+$user_id2 = (int)$input['user_id2'];
+
+try {
+    $db = getDB();
+    $stmt = $db->prepare(
+        "DELETE FROM connections WHERE ((user_id1 = :u1 AND user_id2 = :u2) OR (user_id1 = :u2 AND user_id2 = :u1)) AND status = 'accepted'"
+    );
+    $stmt->execute([':u1' => $user_id1, ':u2' => $user_id2]);
+    if ($stmt->rowCount() === 0) {
+        http_response_code(404);
+        echo json_encode(['success' => false, 'error' => 'Connection not found']);
+        exit;
+    }
+    echo json_encode(['success' => true]);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'error' => 'Database error: ' . $e->getMessage()]);
+}
+?>

--- a/frontend/src/components/Connections.css
+++ b/frontend/src/components/Connections.css
@@ -174,6 +174,41 @@
   .message-button:hover {
     background-color: #0056b3;
   }
+
+  /* 3-dot menu icon */
+  .menu-icon {
+    font-size: 1.2rem;
+    cursor: pointer;
+    color: #777;
+  }
+
+  /* Dropdown menu */
+  .dropdown-menu {
+    background-color: #fff;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+    position: absolute;
+    top: 30px;
+    right: 8px;
+    z-index: 10;
+    width: 140px;
+    padding: 0.25rem 0;
+  }
+
+  .dropdown-item {
+    background: none;
+    border: none;
+    width: 100%;
+    text-align: left;
+    padding: 8px;
+    font-size: 0.9rem;
+    cursor: pointer;
+  }
+
+  .dropdown-item:hover {
+    background-color: #f0f0f0;
+  }
   
   /* Responsive adjustments */
   @media (max-width: 768px) {
@@ -201,4 +236,3 @@
       padding: 5px 10px;
     }
   }
-  

--- a/frontend/src/components/ProfileView.css
+++ b/frontend/src/components/ProfileView.css
@@ -202,6 +202,41 @@
   background-color: #218838;
 }
 
+/* 3-dot menu icon */
+.menu-icon {
+  font-size: 1.2rem;
+  cursor: pointer;
+  color: #777;
+}
+
+/* Dropdown menu */
+.dropdown-menu {
+  background-color: #fff;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+  position: absolute;
+  top: 30px;
+  right: 0;
+  z-index: 10;
+  width: 140px;
+  padding: 0.25rem 0;
+}
+
+.dropdown-item {
+  background: none;
+  border: none;
+  width: 100%;
+  text-align: left;
+  padding: 8px;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.dropdown-item:hover {
+  background-color: #f0f0f0;
+}
+
 /* ===================== */
 /* Ambassador Logos      */
 /* ===================== */


### PR DESCRIPTION
## Summary
- allow removing a connection via new API endpoint
- show options menu in connection lists with Remove and Message
- rework UserProfileView actions with ellipsis menu
- style ellipsis menu for profiles and connections

## Testing
- `npm test --silent -- -w=0` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_684a5c07750883338a72406dd8ec2a23