### PR TITLE
Fix connection pending state

### DIFF
--- a/frontend/src/components/UserProfileView.js
+++ b/frontend/src/components/UserProfileView.js
@@ -267,6 +267,13 @@ const handleConnect = async () => {
       );
       if (res.data.success) {
         setConnectionStatus("pending");
+        // Store the new connection ID returned by the API so we can
+        // cancel the request without refreshing. Since the current
+        // user initiated the request, mark them as the requester.
+        if (res.data.connection_id) {
+          setConnectionId(res.data.connection_id);
+        }
+        setIsRequester(true);
       }
   } catch (err) {
     console.error("Error sending connection request:", err);


### PR DESCRIPTION
## Summary
- ensure the sender sees "Pending" immediately after requesting a connection

## Testing
- `npm test --prefix frontend -- -w=0 --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68520a7be7b08333b1169b288d6b54cc