### PR TITLE
Add community creation request workflow

### DIFF
--- a/backend/community_requests.sql
+++ b/backend/community_requests.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `community_creation_requests` (
+  `request_id` int NOT NULL AUTO_INCREMENT,
+  `user_id` int NOT NULL,
+  `name` varchar(100) NOT NULL,
+  `type` enum('university','group') NOT NULL,
+  `description` text NOT NULL,
+  `status` enum('pending','approved','declined') NOT NULL DEFAULT 'pending',
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`request_id`),
+  KEY `user_id` (`user_id`),
+  CONSTRAINT `fk_request_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`user_id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/backend/public/fetch_community_requests.php
+++ b/backend/public/fetch_community_requests.php
@@ -1,0 +1,25 @@
+<?php
+require_once __DIR__ . '/../db_connection.php';
+session_start();
+header('Content-Type: application/json');
+
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    echo json_encode(['success' => false, 'error' => 'Not logged in']);
+    exit;
+}
+
+$db = getDB();
+$stmt = $db->prepare("SELECT email FROM users WHERE user_id = ?");
+$stmt->execute([$_SESSION['user_id']]);
+$user = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$user || $user['email'] !== 'n.sandore5140@gmail.com') {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'error' => 'Forbidden']);
+    exit;
+}
+
+$requests = $db->query("SELECT r.request_id, r.name, r.type, r.description, r.user_id, u.email, u.first_name, u.last_name FROM community_creation_requests r JOIN users u ON r.user_id = u.user_id WHERE r.status = 'pending' ORDER BY r.created_at DESC")->fetchAll(PDO::FETCH_ASSOC);
+
+echo json_encode(['success' => true, 'requests' => $requests]);
+?>

--- a/backend/public/handle_community_request.php
+++ b/backend/public/handle_community_request.php
@@ -1,0 +1,90 @@
+<?php
+require_once __DIR__ . '/../db_connection.php';
+require __DIR__ . '/../vendor/autoload.php';
+use Mailgun\Mailgun;
+session_start();
+header('Content-Type: application/json');
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input || !isset($input['request_id']) || !isset($input['action'])) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'Missing fields']);
+    exit;
+}
+
+$db = getDB();
+$stmt = $db->prepare("SELECT email FROM users WHERE user_id = ?");
+$stmt->execute([$_SESSION['user_id'] ?? 0]);
+$user = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$user || $user['email'] !== 'n.sandore5140@gmail.com') {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'error' => 'Forbidden']);
+    exit;
+}
+
+$request_id = (int)$input['request_id'];
+$action = $input['action'];
+
+$reqStmt = $db->prepare("SELECT * FROM community_creation_requests WHERE request_id = ?");
+$reqStmt->execute([$request_id]);
+$request = $reqStmt->fetch(PDO::FETCH_ASSOC);
+if (!$request) {
+    http_response_code(404);
+    echo json_encode(['success' => false, 'error' => 'Request not found']);
+    exit;
+}
+
+$status = '';
+if ($action === 'approve') {
+    $cStmt = $db->prepare("INSERT INTO communities (community_type, name, tagline) VALUES (:type, :name, :tag)");
+    $cStmt->execute([
+        ':type' => $request['type'],
+        ':name' => $request['name'],
+        ':tag'  => $request['description']
+    ]);
+    $community_id = $db->lastInsertId();
+    $uStmt = $db->prepare("SELECT email, first_name FROM users WHERE user_id = ?");
+    $uStmt->execute([$request['user_id']]);
+    $u = $uStmt->fetch(PDO::FETCH_ASSOC);
+    $email = $u ? $u['email'] : '';
+    $first = $u ? $u['first_name'] : '';
+    $adm = $db->prepare("INSERT INTO community_admins (community_id, user_email) VALUES (?, ?)");
+    $adm->execute([$community_id, $email]);
+    $status = 'approved';
+} elseif ($action === 'decline') {
+    $status = 'declined';
+} else {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'Invalid action']);
+    exit;
+}
+
+$up = $db->prepare("UPDATE community_creation_requests SET status = ?, updated_at = NOW() WHERE request_id = ?");
+$up->execute([$status, $request_id]);
+
+$uStmt = $db->prepare("SELECT email, first_name FROM users WHERE user_id = ?");
+$uStmt->execute([$request['user_id']]);
+$u = $uStmt->fetch(PDO::FETCH_ASSOC);
+$email = $u ? $u['email'] : '';
+$first = $u ? $u['first_name'] : '';
+
+$mg = Mailgun::create('dba41dc21198fcc4ba525015085cc266-7c5e3295-2c874436');
+$domain = 'sandboxe67f4501277d44af9f736a2154a5b6cb.mailgun.org';
+if ($status === 'approved') {
+    $mg->messages()->send($domain, [
+        'from' => 'StudentSphere <no-reply@studentsphere.com>',
+        'to'   => "$first <$email>",
+        'subject' => 'Community Request Approved',
+        'text' => "Your community request '{$request['name']}' has been approved."
+    ]);
+} else {
+    $mg->messages()->send($domain, [
+        'from' => 'StudentSphere <no-reply@studentsphere.com>',
+        'to'   => "$first <$email>",
+        'subject' => 'Community Request Declined',
+        'text' => "Your community request '{$request['name']}' was declined."
+    ]);
+}
+
+echo json_encode(['success' => true, 'status' => $status]);
+?>

--- a/backend/public/request_community.php
+++ b/backend/public/request_community.php
@@ -1,0 +1,50 @@
+<?php
+require_once __DIR__ . '/../db_connection.php';
+require __DIR__ . '/../vendor/autoload.php';
+use Mailgun\Mailgun;
+
+header('Content-Type: application/json');
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input || empty($input['user_id']) || empty($input['name']) || empty($input['type']) || empty($input['description'])) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'Missing required fields']);
+    exit;
+}
+
+$user_id = (int)$input['user_id'];
+$name = trim($input['name']);
+$type = trim($input['type']);
+$description = trim($input['description']);
+
+try {
+    $db = getDB();
+    $stmt = $db->prepare("INSERT INTO community_creation_requests (user_id, name, type, description, status, created_at, updated_at) VALUES (:uid, :name, :type, :descr, 'pending', NOW(), NOW())");
+    $stmt->execute([
+        ':uid' => $user_id,
+        ':name' => $name,
+        ':type' => $type,
+        ':descr' => $description
+    ]);
+    $request_id = $db->lastInsertId();
+
+    $uStmt = $db->prepare("SELECT email, first_name FROM users WHERE user_id = ?");
+    $uStmt->execute([$user_id]);
+    $user = $uStmt->fetch(PDO::FETCH_ASSOC);
+    $email = $user ? $user['email'] : '';
+    $first = $user ? $user['first_name'] : '';
+
+    $mg = Mailgun::create('dba41dc21198fcc4ba525015085cc266-7c5e3295-2c874436');
+    $domain = 'sandboxe67f4501277d44af9f736a2154a5b6cb.mailgun.org';
+    $mg->messages()->send($domain, [
+        'from' => 'StudentSphere <no-reply@studentsphere.com>',
+        'to'   => 'n.sandore5140@gmail.com',
+        'subject' => 'New Community Request',
+        'text' => "Request from $first <$email>\nName: $name\nType: $type\nDescription: $description"
+    ]);
+
+    echo json_encode(['success' => true, 'request_id' => $request_id]);
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'error' => $e->getMessage()]);
+}
+?>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -52,6 +52,7 @@ import ForumCard from './components/ForumCard';
 import Feed from './components/Feed';
 import ContactUsButton from './components/ContactUsButton';
 import SearchResults from './components/SearchResults';
+import CommunityRequests from './components/CommunityRequests';
 
 
 function App() {
@@ -506,6 +507,10 @@ function App() {
                           <Route
                             path="/messages"
                             element={<Messages userData={userData} />}
+                          />
+                          <Route
+                            path="/community-requests"
+                            element={<CommunityRequests userData={userData} />}
                           />
                           <Route path="/search" element={<SearchResults />} />
                         </Routes>

--- a/frontend/src/components/CommunityRequests.css
+++ b/frontend/src/components/CommunityRequests.css
@@ -1,0 +1,15 @@
+.request-list {
+  list-style: none;
+  padding: 0;
+}
+
+.request-item {
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+.request-actions button {
+  margin-right: 0.5rem;
+}

--- a/frontend/src/components/CommunityRequests.js
+++ b/frontend/src/components/CommunityRequests.js
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
+import './CommunityRequests.css';
+
+function CommunityRequests({ userData }) {
+  const [requests, setRequests] = useState([]);
+  const navigate = useNavigate();
+
+  const fetchRequests = async () => {
+    try {
+      const res = await axios.get('/api/fetch_community_requests.php', { withCredentials: true });
+      if (res.data.success) {
+        setRequests(res.data.requests);
+      }
+    } catch (err) {
+      console.error('Error fetching requests:', err);
+    }
+  };
+
+  useEffect(() => {
+    if (userData) fetchRequests();
+  }, [userData]);
+
+  const handleAction = async (request_id, action) => {
+    try {
+      const res = await axios.post('/api/handle_community_request.php', { request_id, action }, { withCredentials: true });
+      if (res.data.success) fetchRequests();
+    } catch (err) {
+      console.error('Error updating request:', err);
+    }
+  };
+
+  return (
+    <main>
+      <div className="feed-container">
+        <h2>Community Creation Requests</h2>
+        {requests.length === 0 ? (
+          <p>No pending requests.</p>
+        ) : (
+          <ul className="request-list">
+            {requests.map((r) => (
+              <li key={r.request_id} className="request-item">
+                <h4>{r.name} ({r.type})</h4>
+                <p>{r.description}</p>
+                <div className="request-actions">
+                  <button onClick={() => handleAction(r.request_id, 'approve')}>Approve</button>
+                  <button onClick={() => handleAction(r.request_id, 'decline')}>Decline</button>
+                  <button onClick={() => navigate(`/messages?user=${r.user_id}`)}>Message</button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </main>
+  );
+}
+
+export default CommunityRequests;

--- a/frontend/src/components/Feed.js
+++ b/frontend/src/components/Feed.js
@@ -36,6 +36,12 @@ function Feed({ activeFeed, setActiveFeed, activeSection, userData }) {
   const [newForumDescription, setNewForumDescription] = useState('');
   const [isCreatingForum, setIsCreatingForum] = useState(false);
 
+  const [showRequestModal, setShowRequestModal] = useState(false);
+  const [requestName, setRequestName] = useState('');
+  const [requestType, setRequestType] = useState('university');
+  const [requestDesc, setRequestDesc] = useState('');
+  const [isSubmittingRequest, setIsSubmittingRequest] = useState(false);
+
   const [editForumId, setEditForumId] = useState(null);
   const [editForumName, setEditForumName] = useState('');
   const [editForumDescription, setEditForumDescription] = useState('');
@@ -467,6 +473,31 @@ function Feed({ activeFeed, setActiveFeed, activeSection, userData }) {
     }
   };
 
+  const handleRequestSubmit = async (e) => {
+    e.preventDefault();
+    if (!userData) return;
+    setIsSubmittingRequest(true);
+    try {
+      const resp = await axios.post('/api/request_community.php', {
+        user_id: userData.user_id,
+        name: requestName,
+        type: requestType,
+        description: requestDesc
+      }, { withCredentials: true });
+      if (resp.data.success) {
+        setRequestName('');
+        setRequestDesc('');
+        setShowRequestModal(false);
+      } else {
+        alert(resp.data.error || 'Error sending request');
+      }
+    } catch (err) {
+      console.error('Error requesting community:', err);
+    } finally {
+      setIsSubmittingRequest(false);
+    }
+  };
+
   // ------------- HOME FEED -------------
   // Re-fetch feed threads if userData changes or the feed changes
   useEffect(() => {
@@ -661,19 +692,29 @@ function Feed({ activeFeed, setActiveFeed, activeSection, userData }) {
           </div>
 
           {/* Community Type Tabs */}
-          <div className="community-tab" style={{ marginBottom: '1rem' }}>
-            <button
-              onClick={() => setSelectedCommunityTab("university")}
-              className={selectedCommunityTab === "university" ? "active" : ""}
-            >
-              Universities
-            </button>
-            <button
-              onClick={() => setSelectedCommunityTab("group")}
-              className={selectedCommunityTab === "group" ? "active" : ""}
-            >
-              Groups
-            </button>
+          <div
+            className="community-tab"
+            style={{ marginBottom: '1rem', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
+          >
+            <div>
+              <button
+                onClick={() => setSelectedCommunityTab('university')}
+                className={selectedCommunityTab === 'university' ? 'active' : ''}
+              >
+                Universities
+              </button>
+              <button
+                onClick={() => setSelectedCommunityTab('group')}
+                className={selectedCommunityTab === 'group' ? 'active' : ''}
+              >
+                Groups
+              </button>
+            </div>
+            {userData && (
+              <button className="non-togglable-button" onClick={() => setShowRequestModal(true)}>
+                Request New
+              </button>
+            )}
           </div>
 
           {/* Search Bar */}
@@ -859,6 +900,55 @@ function Feed({ activeFeed, setActiveFeed, activeSection, userData }) {
                   <div className="form-actions">
                     <button type="submit">Save</button>
                     <button type="button" onClick={cancelEditingForum}>
+                      Cancel
+                    </button>
+                  </div>
+                </form>
+              </div>
+            </div>
+          )}
+
+          {/* REQUEST COMMUNITY MODAL */}
+          {showRequestModal && (
+            <div className="modal-overlay">
+              <div className="modal-content">
+                <h3>Request New Community</h3>
+                <form onSubmit={handleRequestSubmit}>
+                  <div className="form-group">
+                    <label htmlFor="req-name">Name:</label>
+                    <input
+                      id="req-name"
+                      type="text"
+                      value={requestName}
+                      onChange={(e) => setRequestName(e.target.value)}
+                      required
+                    />
+                  </div>
+                  <div className="form-group">
+                    <label htmlFor="req-type">Type:</label>
+                    <select
+                      id="req-type"
+                      value={requestType}
+                      onChange={(e) => setRequestType(e.target.value)}
+                    >
+                      <option value="university">University</option>
+                      <option value="group">Group</option>
+                    </select>
+                  </div>
+                  <div className="form-group">
+                    <label htmlFor="req-desc">Description:</label>
+                    <textarea
+                      id="req-desc"
+                      value={requestDesc}
+                      onChange={(e) => setRequestDesc(e.target.value)}
+                      required
+                    />
+                  </div>
+                  <div className="form-actions">
+                    <button type="submit" disabled={isSubmittingRequest}>
+                      {isSubmittingRequest ? 'Sending...' : 'Submit'}
+                    </button>
+                    <button type="button" onClick={() => setShowRequestModal(false)}>
                       Cancel
                     </button>
                   </div>

--- a/frontend/src/components/NavBar.js
+++ b/frontend/src/components/NavBar.js
@@ -158,12 +158,20 @@ function NavBar({
             Icon={RiMedalFill} 
             onClick={() => handleSectionClick('funding')} 
           />
-          <NavItem 
-            active={activeSection === 'communities'} 
-            label="Communities" 
-            Icon={FaUsers} 
-            onClick={() => handleSectionClick('communities')} 
+          <NavItem
+            active={activeSection === 'communities'}
+            label="Communities"
+            Icon={FaUsers}
+            onClick={() => handleSectionClick('communities')}
           />
+          {userData && userData.email === 'n.sandore5140@gmail.com' && (
+            <NavItem
+              active={activeSection === 'community-requests'}
+              label="Requests"
+              Icon={FaEnvelope}
+              onClick={() => handleSectionClick('community-requests')}
+            />
+          )}
 
           {userData && (
             <>


### PR DESCRIPTION
## Summary
- add database schema for community creation requests
- add PHP endpoints for requesting, fetching and handling requests
- show new community request button in the communities tab
- allow admins to approve or decline requests
- add CommunityRequests page and admin nav link

## Testing
- `npm test --silent --prefix frontend -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685214fa65808333bfd98a03b81ba2be