### PR TITLE
Add community creation request system

### DIFF
--- a/backend/public/get_community_requests.php
+++ b/backend/public/get_community_requests.php
@@ -1,0 +1,22 @@
+<?php
+session_start();
+require_once __DIR__ . '/../db_connection.php';
+
+header('Content-Type: application/json');
+
+if (!isset($_SESSION['user_id']) || $_SESSION['email'] !== 'n.sandore5140@gmail.com') {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'error' => 'Unauthorized']);
+    exit;
+}
+
+try {
+    $db = getDB();
+    $stmt = $db->query("SELECT r.id, r.name, r.community_type, r.description, r.status, r.created_at, u.email AS requester_email FROM community_creation_requests r JOIN users u ON r.user_id = u.user_id WHERE r.status = 'pending' ORDER BY r.created_at DESC");
+    $requests = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    echo json_encode(['success' => true, 'requests' => $requests]);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'error' => 'Database error: ' . $e->getMessage()]);
+}
+?>

--- a/backend/public/handle_community_request.php
+++ b/backend/public/handle_community_request.php
@@ -1,0 +1,85 @@
+<?php
+session_start();
+require_once __DIR__ . '/../db_connection.php';
+require __DIR__ . '/../vendor/autoload.php';
+use Mailgun\Mailgun;
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'error' => 'Method not allowed']);
+    exit;
+}
+
+if (!isset($_SESSION['user_id']) || $_SESSION['email'] !== 'n.sandore5140@gmail.com') {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'error' => 'Unauthorized']);
+    exit;
+}
+
+$data = json_decode(file_get_contents('php://input'), true);
+$requestId = (int)($data['request_id'] ?? 0);
+$action = $data['action'] ?? '';
+
+if ($requestId <= 0 || !in_array($action, ['approve','decline'])) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'Invalid parameters']);
+    exit;
+}
+
+try {
+    $db = getDB();
+    $stmt = $db->prepare("SELECT r.*, u.email FROM community_creation_requests r JOIN users u ON r.user_id = u.user_id WHERE r.id = :id");
+    $stmt->execute([':id' => $requestId]);
+    $request = $stmt->fetch(PDO::FETCH_ASSOC);
+    if (!$request) {
+        http_response_code(404);
+        echo json_encode(['success' => false, 'error' => 'Request not found']);
+        exit;
+    }
+
+    if ($action === 'approve') {
+        // create community with minimal info
+        $stmt = $db->prepare("INSERT INTO communities (community_type, name, tagline) VALUES (:type, :name, :tagline)");
+        $stmt->execute([
+            ':type' => $request['community_type'],
+            ':name' => $request['name'],
+            ':tagline' => $request['description']
+        ]);
+        $communityId = $db->lastInsertId();
+        // add admin
+        $stmt = $db->prepare("INSERT INTO community_admins (community_id, user_email) VALUES (:cid, :email)");
+        $stmt->execute([':cid' => $communityId, ':email' => $request['email']]);
+        $status = 'approved';
+    } else {
+        $status = 'declined';
+    }
+
+    $stmt = $db->prepare("UPDATE community_creation_requests SET status = :status WHERE id = :id");
+    $stmt->execute([':status' => $status, ':id' => $requestId]);
+
+    // send email to requester
+    try {
+        $mg = Mailgun::create('dba41dc21198fcc4ba525015085cc266-7c5e3295-2c874436');
+        $domain = 'sandboxe67f4501277d44af9f736a2154a5b6cb.mailgun.org';
+        $subject = $status === 'approved' ? 'Community Request Approved' : 'Community Request Declined';
+        $text = $status === 'approved'
+            ? "Your community request '{$request['name']}' has been approved."
+            : "Your community request '{$request['name']}' has been declined.";
+        $mg->messages()->send($domain, [
+            'from' => 'noreply@studentsphere.com',
+            'to' => $request['email'],
+            'subject' => $subject,
+            'text' => $text
+        ]);
+    } catch (Exception $e) {
+        // ignore mailgun errors
+    }
+
+    echo json_encode(['success' => true]);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'error' => 'Database error: ' . $e->getMessage()]);
+}
+?>

--- a/backend/public/request_community.php
+++ b/backend/public/request_community.php
@@ -1,0 +1,65 @@
+<?php
+session_start();
+require_once __DIR__ . '/../db_connection.php';
+require __DIR__ . '/../vendor/autoload.php';
+use Mailgun\Mailgun;
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'error' => 'Method not allowed']);
+    exit;
+}
+
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'error' => 'Not authenticated']);
+    exit;
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+$name = trim($input['name'] ?? '');
+$type = trim($input['type'] ?? '');
+$description = trim($input['description'] ?? '');
+
+if ($name === '' || $type === '' || $description === '') {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'Missing required fields']);
+    exit;
+}
+
+$userId = (int)$_SESSION['user_id'];
+$userEmail = $_SESSION['email'] ?? '';
+
+try {
+    $db = getDB();
+    $stmt = $db->prepare("INSERT INTO community_creation_requests (user_id, name, community_type, description, status, created_at) VALUES (:uid, :name, :type, :description, 'pending', NOW())");
+    $stmt->execute([
+        ':uid' => $userId,
+        ':name' => $name,
+        ':type' => $type,
+        ':description' => $description
+    ]);
+    $requestId = $db->lastInsertId();
+
+    // send email to admin
+    try {
+        $mg = Mailgun::create('dba41dc21198fcc4ba525015085cc266-7c5e3295-2c874436');
+        $domain = 'sandboxe67f4501277d44af9f736a2154a5b6cb.mailgun.org';
+        $mg->messages()->send($domain, [
+            'from' => 'noreply@studentsphere.com',
+            'to' => 'n.sandore5140@gmail.com',
+            'subject' => 'New Community Creation Request',
+            'text' => "User $userEmail requested a new community:\nName: $name\nType: $type\nDescription: $description"
+        ]);
+    } catch (Exception $e) {
+        // ignore mailgun errors but log if needed
+    }
+
+    echo json_encode(['success' => true, 'request_id' => $requestId]);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'error' => 'Database error: ' . $e->getMessage()]);
+}
+?>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -52,6 +52,7 @@ import ForumCard from './components/ForumCard';
 import Feed from './components/Feed';
 import ContactUsButton from './components/ContactUsButton';
 import SearchResults from './components/SearchResults';
+import CommunityRequests from './components/CommunityRequests';
 
 
 function App() {
@@ -479,6 +480,18 @@ function App() {
                                 activeSection="communities"
                                 userData={userData}
                               />
+                            }
+                          />
+
+                          {/* Community Creation Requests */}
+                          <Route
+                            path="/community-requests"
+                            element={
+                              userData && userData.email === 'n.sandore5140@gmail.com' ? (
+                                <CommunityRequests />
+                              ) : (
+                                <Navigate to="/communities" />
+                              )
                             }
                           />
 

--- a/frontend/src/components/CommunityRequestModal.css
+++ b/frontend/src/components/CommunityRequestModal.css
@@ -1,0 +1,74 @@
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: #fff;
+  padding: 2rem;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 500px;
+  box-shadow: 0 5px 15px rgba(0,0,0,0.3);
+}
+
+[data-theme="dark"] .modal-content {
+  background: #2d2d2d;
+}
+
+.form-group {
+  margin-bottom: 1rem;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: bold;
+}
+
+.form-group input,
+.form-group textarea,
+.form-group select {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 1rem;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+}
+
+.form-actions button {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.form-actions button[type="submit"] {
+  background-color: #28a745;
+  color: #fff;
+}
+
+.form-actions button[type="submit"]:disabled {
+  background-color: #6c757d;
+  cursor: not-allowed;
+}
+
+.form-actions button[type="button"] {
+  background-color: #dc3545;
+  color: #fff;
+}

--- a/frontend/src/components/CommunityRequestModal.js
+++ b/frontend/src/components/CommunityRequestModal.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import './CommunityRequestModal.css';
+
+function CommunityRequestModal({ isVisible, onClose, onSubmit, formData, setFormData, isSubmitting }) {
+  if (!isVisible) return null;
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({ ...prev, [name]: value }));
+  };
+
+  return (
+    <div className="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="request-modal-title">
+      <div className="modal-content">
+        <h3 id="request-modal-title">Request New Community</h3>
+        <form onSubmit={onSubmit}>
+          <div className="form-group">
+            <label htmlFor="community-name">Name:</label>
+            <input
+              type="text"
+              id="community-name"
+              name="name"
+              value={formData.name}
+              onChange={handleChange}
+              required
+            />
+          </div>
+          <div className="form-group">
+            <label htmlFor="community-type">Type:</label>
+            <select
+              id="community-type"
+              name="type"
+              value={formData.type}
+              onChange={handleChange}
+              required
+            >
+              <option value="">Select...</option>
+              <option value="university">University</option>
+              <option value="group">Group</option>
+            </select>
+          </div>
+          <div className="form-group">
+            <label htmlFor="community-description">Description:</label>
+            <textarea
+              id="community-description"
+              name="description"
+              value={formData.description}
+              onChange={handleChange}
+              required
+            ></textarea>
+          </div>
+          <div className="form-actions">
+            <button type="submit" disabled={isSubmitting}>{isSubmitting ? 'Submitting...' : 'Submit'}</button>
+            <button type="button" onClick={onClose}>Cancel</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+CommunityRequestModal.propTypes = {
+  isVisible: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  formData: PropTypes.object.isRequired,
+  setFormData: PropTypes.func.isRequired,
+  isSubmitting: PropTypes.bool.isRequired,
+};
+
+export default CommunityRequestModal;

--- a/frontend/src/components/CommunityRequests.css
+++ b/frontend/src/components/CommunityRequests.css
@@ -1,0 +1,37 @@
+.requests-container {
+  padding: 1rem;
+}
+
+.request-list {
+  list-style: none;
+  padding: 0;
+}
+
+.request-item {
+  border: 1px solid #ccc;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  border-radius: 8px;
+}
+
+.request-actions {
+  margin-top: 0.5rem;
+}
+
+.request-actions button {
+  margin-right: 0.5rem;
+  padding: 0.3rem 0.6rem;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.request-actions button:first-child {
+  background-color: #28a745;
+  color: #fff;
+}
+
+.request-actions button:last-child {
+  background-color: #dc3545;
+  color: #fff;
+}

--- a/frontend/src/components/CommunityRequests.js
+++ b/frontend/src/components/CommunityRequests.js
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import './CommunityRequests.css';
+
+function CommunityRequests() {
+  const [requests, setRequests] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchRequests = async () => {
+      try {
+        const res = await axios.get('/api/get_community_requests.php', { withCredentials: true });
+        if (res.data.success) {
+          setRequests(res.data.requests);
+        }
+      } catch (err) {
+        console.error('Error fetching requests:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchRequests();
+  }, []);
+
+  const handleAction = async (id, action) => {
+    if (!window.confirm(`Are you sure you want to ${action} this request?`)) return;
+    try {
+      const res = await axios.post('/api/handle_community_request.php', { request_id: id, action }, { withCredentials: true });
+      if (res.data.success) {
+        setRequests(prev => prev.filter(r => r.id !== id));
+      } else {
+        alert(res.data.error || 'Error processing request');
+      }
+    } catch (err) {
+      console.error('Error:', err);
+    }
+  };
+
+  return (
+    <div className="requests-container">
+      <h2>Community Creation Requests</h2>
+      {loading ? (
+        <p>Loading...</p>
+      ) : requests.length === 0 ? (
+        <p>No pending requests.</p>
+      ) : (
+        <ul className="request-list">
+          {requests.map(req => (
+            <li key={req.id} className="request-item">
+              <h4>{req.name} ({req.community_type})</h4>
+              <p>{req.description}</p>
+              <div className="request-actions">
+                <button onClick={() => handleAction(req.id, 'approve')}>Approve</button>
+                <button onClick={() => handleAction(req.id, 'decline')}>Decline</button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default CommunityRequests;


### PR DESCRIPTION
## Summary
- add PHP endpoints for requesting community creation and for admin review
- create React components for community request modal and admin request list
- integrate modal into Communities tab and add new route for admin

## Testing
- `npm test --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685216a736c0833381dc508f0c671d00