### PR TITLE
Extend community request data

### DIFF
--- a/backend/public/get_community_requests.php
+++ b/backend/public/get_community_requests.php
@@ -12,7 +12,7 @@ if (!isset($_SESSION['user_id']) || $_SESSION['email'] !== 'n.sandore5140@gmail.
 
 try {
     $db = getDB();
-    $stmt = $db->query("SELECT r.id, r.name, r.community_type, r.description, r.status, r.created_at, u.email AS requester_email FROM community_creation_requests r JOIN users u ON r.user_email = u.email WHERE r.status = 'pending' ORDER BY r.created_at DESC");
+    $stmt = $db->query("SELECT r.id, r.name, r.community_type, r.description, r.tagline, r.location, r.website, r.primary_color, r.secondary_color, r.status, r.created_at, u.email AS requester_email FROM community_creation_requests r JOIN users u ON r.user_email = u.email WHERE r.status = 'pending' ORDER BY r.created_at DESC");
     $requests = $stmt->fetchAll(PDO::FETCH_ASSOC);
     echo json_encode(['success' => true, 'requests' => $requests]);
 } catch (PDOException $e) {

--- a/backend/public/handle_community_request.php
+++ b/backend/public/handle_community_request.php
@@ -40,12 +40,19 @@ try {
     }
 
     if ($action === 'approve') {
-        // create community with minimal info
-        $stmt = $db->prepare("INSERT INTO communities (community_type, name, tagline) VALUES (:type, :name, :tagline)");
+        // create community with provided info
+        $stmt = $db->prepare(
+            "INSERT INTO communities (community_type, name, tagline, location, website, primary_color, secondary_color) " .
+            "VALUES (:type, :name, :tagline, :location, :website, :primary_color, :secondary_color)"
+        );
         $stmt->execute([
             ':type' => $request['community_type'],
             ':name' => $request['name'],
-            ':tagline' => $request['description']
+            ':tagline' => $request['tagline'],
+            ':location' => $request['location'],
+            ':website' => $request['website'],
+            ':primary_color' => $request['primary_color'] ?: '#0077B5',
+            ':secondary_color' => $request['secondary_color'] ?: '#005f8d'
         ]);
         $communityId = $db->lastInsertId();
         // add admin

--- a/backend/public/request_community.php
+++ b/backend/public/request_community.php
@@ -22,6 +22,11 @@ $input = json_decode(file_get_contents('php://input'), true);
 $name = trim($input['name'] ?? '');
 $type = trim($input['type'] ?? '');
 $description = trim($input['description'] ?? '');
+$tagline = trim($input['tagline'] ?? '');
+$location = trim($input['location'] ?? '');
+$website = trim($input['website'] ?? '');
+$primaryColor = trim($input['primary_color'] ?? '');
+$secondaryColor = trim($input['secondary_color'] ?? '');
 
 if ($name === '' || $type === '' || $description === '') {
     http_response_code(400);
@@ -34,12 +39,17 @@ $userEmail = $_SESSION['email'] ?? '';
 
 try {
     $db = getDB();
-    $stmt = $db->prepare("INSERT INTO community_creation_requests (user_email, name, community_type, description, status, created_at) VALUES (:email, :name, :type, :description, 'pending', NOW())");
+    $stmt = $db->prepare("INSERT INTO community_creation_requests (user_email, name, community_type, description, tagline, location, website, primary_color, secondary_color, status, created_at) VALUES (:email, :name, :type, :description, :tagline, :location, :website, :primary_color, :secondary_color, 'pending', NOW())");
     $stmt->execute([
         ':email' => $userEmail,
         ':name' => $name,
         ':type' => $type,
-        ':description' => $description
+        ':description' => $description,
+        ':tagline' => $tagline,
+        ':location' => $location,
+        ':website' => $website,
+        ':primary_color' => $primaryColor,
+        ':secondary_color' => $secondaryColor
     ]);
 
     $requestId = $db->lastInsertId();
@@ -52,7 +62,7 @@ try {
             'from' => 'noreply@studentsphere.com',
             'to' => 'n.sandore5140@gmail.com',
             'subject' => 'New Community Creation Request',
-            'text' => "User $userEmail requested a new community:\nName: $name\nType: $type\nDescription: $description"
+            'text' => "User $userEmail requested a new community:\nName: $name\nType: $type\nTagline: $tagline\nLocation: $location\nWebsite: $website\nPrimary Color: $primaryColor\nSecondary Color: $secondaryColor\nDescription: $description"
         ]);
     } catch (Exception $e) {
         // ignore mailgun errors but log if needed

--- a/frontend/src/components/CommunityRequestModal.js
+++ b/frontend/src/components/CommunityRequestModal.js
@@ -27,6 +27,58 @@ function CommunityRequestModal({ isVisible, onClose, onSubmit, formData, setForm
             />
           </div>
           <div className="form-group">
+            <label htmlFor="community-tagline">Tagline:</label>
+            <input
+              type="text"
+              id="community-tagline"
+              name="tagline"
+              value={formData.tagline}
+              onChange={handleChange}
+            />
+          </div>
+          <div className="form-group">
+            <label htmlFor="community-location">Location:</label>
+            <input
+              type="text"
+              id="community-location"
+              name="location"
+              value={formData.location}
+              onChange={handleChange}
+            />
+          </div>
+          <div className="form-group">
+            <label htmlFor="community-website">Website:</label>
+            <input
+              type="text"
+              id="community-website"
+              name="website"
+              value={formData.website}
+              onChange={handleChange}
+            />
+          </div>
+          <div className="form-group">
+            <label htmlFor="primary-color">Primary Color:</label>
+            <input
+              type="text"
+              id="primary-color"
+              name="primary_color"
+              value={formData.primary_color}
+              onChange={handleChange}
+              placeholder="#0077B5"
+            />
+          </div>
+          <div className="form-group">
+            <label htmlFor="secondary-color">Secondary Color:</label>
+            <input
+              type="text"
+              id="secondary-color"
+              name="secondary_color"
+              value={formData.secondary_color}
+              onChange={handleChange}
+              placeholder="#005f8d"
+            />
+          </div>
+          <div className="form-group">
             <label htmlFor="community-type">Type:</label>
             <select
               id="community-type"

--- a/frontend/src/components/Feed.js
+++ b/frontend/src/components/Feed.js
@@ -49,7 +49,16 @@ function Feed({ activeFeed, setActiveFeed, activeSection, userData }) {
 
   // Community creation request modal
   const [showRequestModal, setShowRequestModal] = useState(false);
-  const [requestData, setRequestData] = useState({ name: '', type: '', description: '' });
+  const [requestData, setRequestData] = useState({
+    name: '',
+    type: '',
+    description: '',
+    tagline: '',
+    location: '',
+    website: '',
+    primary_color: '',
+    secondary_color: ''
+  });
   const [isSubmittingRequest, setIsSubmittingRequest] = useState(false);
 
   // ============== S A V E D ==============
@@ -481,7 +490,16 @@ function Feed({ activeFeed, setActiveFeed, activeSection, userData }) {
     try {
       const resp = await axios.post('/api/request_community.php', requestData, { withCredentials: true });
       if (resp.data.success) {
-        setRequestData({ name: '', type: '', description: '' });
+        setRequestData({
+          name: '',
+          type: '',
+          description: '',
+          tagline: '',
+          location: '',
+          website: '',
+          primary_color: '',
+          secondary_color: ''
+        });
         setShowRequestModal(false);
         setNotification({ type: 'success', message: 'Request submitted.' });
       } else {


### PR DESCRIPTION
## Summary
- allow optional tagline, location, website and color inputs on community creation requests
- store these new fields server side for admin approval
- include them when approving a request and when fetching pending requests
- update frontend forms and state handling for the extra fields

## Testing
- `CI=true npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685226a858308333b7703c695b2ac1c8