### PR TITLE
Add community admin support

### DIFF
--- a/backend/public/check_session.php
+++ b/backend/public/check_session.php
@@ -14,7 +14,8 @@ if (isset($_SESSION['user_id'])) {
             "avatar_path" => $_SESSION['avatar_path'],
             "is_ambassador" => $_SESSION['is_ambassador'],
             "login_count" => $_SESSION['login_count'],
-            "is_public" => $_SESSION['is_public']
+            "is_public" => $_SESSION['is_public'],
+            "admin_community_ids" => $_SESSION['admin_community_ids'] ?? []
         ]
     ]);
 } else {

--- a/backend/public/get_user_community_admins.php
+++ b/backend/public/get_user_community_admins.php
@@ -1,0 +1,22 @@
+<?php
+session_start();
+header('Content-Type: application/json');
+require_once __DIR__ . '/../db_connection.php';
+
+if (!isset($_SESSION['user_id']) || !isset($_SESSION['email'])) {
+    http_response_code(401);
+    echo json_encode(['success' => false, 'error' => 'Not logged in']);
+    exit;
+}
+
+try {
+    $db = getDB();
+    $stmt = $db->prepare('SELECT community_id FROM community_admins WHERE user_email = :email');
+    $stmt->execute([':email' => $_SESSION['email']]);
+    $communities = $stmt->fetchAll(PDO::FETCH_COLUMN);
+    echo json_encode(['success' => true, 'communities' => $communities]);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'error' => 'Database error: ' . $e->getMessage()]);
+}
+?>

--- a/backend/public/login_user.php
+++ b/backend/public/login_user.php
@@ -41,6 +41,16 @@ try {
         $_SESSION['login_count'] = $user['login_count'];
         $_SESSION['is_public'] = $user['is_public'];
 
+        // Fetch communities that this user administers if applicable
+        $communityIds = [];
+        if ($user['role_id'] >= 5 && $user['role_id'] < 7) {
+            $cStmt = $db->prepare("SELECT community_id FROM community_admins WHERE user_email = :email");
+            $cStmt->execute([':email' => $user['email']]);
+            $communityIds = $cStmt->fetchAll(PDO::FETCH_COLUMN);
+        }
+        $_SESSION['admin_community_ids'] = $communityIds;
+        $user['admin_community_ids'] = $communityIds;
+
         echo json_encode([
             "success" => true,
             "user" => $user


### PR DESCRIPTION
## Summary
- keep list of communities a user manages in the session during login
- expose those communities via `check_session.php`
- new endpoint `get_user_community_admins.php` to fetch admin communities

## Testing
- `CI=true npm test --prefix frontend --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68627ef6d4b883339c823b3e6c9e3873