### PR TITLE
Fix ambassador search to exclude community admins

### DIFF
--- a/backend/public/search_users.php
+++ b/backend/public/search_users.php
@@ -4,6 +4,7 @@ require_once __DIR__ . '/../db_connection.php';
 header('Content-Type: application/json');
 
 $term = isset($_GET['term']) ? trim($_GET['term']) : '';
+$excludeCommunity = isset($_GET['exclude_admins_of']) ? (int)$_GET['exclude_admins_of'] : 0;
 if ($term === '') {
     echo json_encode(['success' => true, 'users' => []]);
     exit;
@@ -12,8 +13,32 @@ if ($term === '') {
 try {
     $db = getDB();
     $like = '%' . $term . '%';
-    $stmt = $db->prepare("SELECT user_id, first_name, last_name, email, avatar_path, is_public FROM users WHERE first_name LIKE :term OR last_name LIKE :term OR email LIKE :term ORDER BY first_name LIMIT 10");
-    $stmt->bindValue(':term', $like, PDO::PARAM_STR);
+
+    if ($excludeCommunity > 0) {
+        $query = "SELECT u.user_id, u.first_name, u.last_name, u.email, u.avatar_path, u.is_public
+                  FROM users u
+                  WHERE (u.first_name LIKE :term OR u.last_name LIKE :term OR u.email LIKE :term)
+                    AND u.user_id NOT IN (
+                        SELECT u2.user_id
+                        FROM community_admins ca
+                        JOIN users u2 ON ca.user_email = u2.email
+                        WHERE ca.community_id = :community_id
+                    )
+                  ORDER BY u.first_name
+                  LIMIT 10";
+        $stmt = $db->prepare($query);
+        $stmt->bindValue(':term', $like, PDO::PARAM_STR);
+        $stmt->bindValue(':community_id', $excludeCommunity, PDO::PARAM_INT);
+    } else {
+        $stmt = $db->prepare(
+            "SELECT user_id, first_name, last_name, email, avatar_path, is_public
+             FROM users
+             WHERE first_name LIKE :term OR last_name LIKE :term OR email LIKE :term
+             ORDER BY first_name LIMIT 10"
+        );
+        $stmt->bindValue(':term', $like, PDO::PARAM_STR);
+    }
+
     $stmt->execute();
     $users = $stmt->fetchAll(PDO::FETCH_ASSOC);
 

--- a/frontend/src/components/UniversityProfile.js
+++ b/frontend/src/components/UniversityProfile.js
@@ -271,7 +271,9 @@ function UniversityProfile({ userData }) {
       return;
     }
     try {
-      const response = await axios.get(`/api/search_users.php?term=${encodeURIComponent(term)}`);
+      const response = await axios.get(
+        `/api/search_users.php?term=${encodeURIComponent(term)}&exclude_admins_of=${id}`
+      );
       if (response.data.success) {
         setSearchResults(response.data.users);
       }


### PR DESCRIPTION
## Summary
- filter community admins in `search_users.php`
- include the community ID when searching for users

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864b73fbb2483339b156c136d4ab3a8